### PR TITLE
Use Animated

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Do an `npm i react-native-gesture-recognizers` and then try out one of the examp
 
 ## Basic panning example
 ```javascript
-import React, { Component, Text, View } from 'react-native';
+import React, { Component, Text, View, Animated } from 'react-native';
 import { pannable } from 'react-native-gesture-recognizers';
 
 @pannable({
@@ -20,7 +20,7 @@ class PanMe {
 
   render() {
     return (
-      <View style={{width:100, height: 100}}>
+      <View style={{width:100, height: 100, backgroundColor: 'red'}}>
         <Text>Pan me!</Text>
       </View>
     );
@@ -32,16 +32,14 @@ class TransformOnPan extends Component {
   constructor(props, context) {
     super(props, context);
     this.state = {
-      transform: [],
+      transform: new Animated.ValueXY(),
     }
   }
 
   onPan = ({ absoluteChangeX, absoluteChangeY }) => {
-    this.setState({
-      transform: [
-        {translateX: absoluteChangeX},
-        {translateY: absoluteChangeY}
-      ]
+    this.state.transform.setValue({
+      x: absoluteChangeX,
+      y: absoluteChangeY,
     });
   }
 
@@ -54,7 +52,7 @@ class TransformOnPan extends Component {
       // due to the wrapping view staying in place and receiving touches
       <PanMe
         onPan={this.onPan}
-        panDecoratorStyle={{transform}} />
+        panDecoratorStyle={{transform: transform.getTranslateTransform()}} />
     );
   }
 }

--- a/src/recognizers/pannable.js
+++ b/src/recognizers/pannable.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import React, { PropTypes, Component, View, PanResponder } from 'react-native';
+import React, { PropTypes, Component, View, PanResponder, Animated } from 'react-native';
 
 const initialState = {
   absoluteChangeX: 0,
@@ -116,9 +116,9 @@ export default ({
       };
 
       return (
-        <View {...this.panResponder.panHandlers} style={style}>
+        <Animated.View {...this.panResponder.panHandlers} style={style}>
           <BaseComponent {...props} {...this.state} />
-        </View>
+        </Animated.View>
       );
     }
   };


### PR DESCRIPTION
Thankfully, because of the way you've built `pannable`, it was easy to simply make the container view an `Animated.View`, and get way better performance when panning as long as you supply an `Animated.ValueXY` to the style, which I show in the updated example. You can choose to not use `Animated.ValueXY` if you want and it will still work.

Using the `setState` method I was getting panning where the red box was terribly trailing my finger. With this change, the red box stayed right with my finger.

I haven't made this change on `swipeable`, but it should be fairly the same idea.
